### PR TITLE
Seperate Saveloc(tp) cooldowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-> [!WARNING]  
-> This Project is discontinued. Feel free to fork it and build upon it.
+Plugin forked from deafps/SharpTimer
+
+I seperated the saveloc command cooldown on the config so the command for loading the loc (checkpoint) would have its own cooldown:
+
+sharptimer_command_spam_cooldown	0.5                                     // Defines the time in seconds between commands can be called. 		Default value: 0.5
+sharptimer_command_saveloc_cooldown     0.2                                     // Defines the time in seconds between saveloc can be called (loadloc). Default value: 0.2
+
+(config.cfg)
 
 
 # SharpTimer

--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -18,6 +18,7 @@ sharptimer_connect_commands_msg_enabled             true                        
 sharptimer_kill_pointservercommand_entities         true                                    // If "true" the plugin will kill all point_servercommand ents on map start (necessary to make xplay maps playable. 🖕 @xplay). Default value: true
 sharptimer_custom_map_cfgs_enabled                  true                                    // Whether Custom Map .cfg files should be executed for the corresponding maps (found in cfg/SharpTimer/MapData/MapExecs/kz_example.cfg). Default value: true
 sharptimer_command_spam_cooldown                    0.5                                     // Defines the time in seconds between commands can be called. Default value: 0.5
+sharptimer_command_saveloc_cooldown                 0.1                                     // Defines the time in seconds between saveloc can be called. Default value: 0.1
 sharptimer_remove_legs                              true                                    // Whether Legs should be removed or not. Default value: true
 sharptimer_remove_collision                         true                                    // Whether player collision should be removed or not. Default value: true
 sharptimer_remove_damage                            true                                    // Whether dealing damage should be disabled or not (will crash with cs2fixes since they hook/detour damage regardless of you using their feature). Default value: true

--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -18,7 +18,7 @@ sharptimer_connect_commands_msg_enabled             true                        
 sharptimer_kill_pointservercommand_entities         true                                    // If "true" the plugin will kill all point_servercommand ents on map start (necessary to make xplay maps playable. 🖕 @xplay). Default value: true
 sharptimer_custom_map_cfgs_enabled                  true                                    // Whether Custom Map .cfg files should be executed for the corresponding maps (found in cfg/SharpTimer/MapData/MapExecs/kz_example.cfg). Default value: true
 sharptimer_command_spam_cooldown                    0.5                                     // Defines the time in seconds between commands can be called. Default value: 0.5
-sharptimer_command_saveloc_cooldown                 0.1                                     // Defines the time in seconds between saveloc can be called. Default value: 0.1
+sharptimer_command_saveloc_cooldown                 0.2                                     // Defines the time in seconds between saveloc can be called. Default value: 0.2
 sharptimer_remove_legs                              true                                    // Whether Legs should be removed or not. Default value: true
 sharptimer_remove_collision                         true                                    // Whether player collision should be removed or not. Default value: true
 sharptimer_remove_damage                            true                                    // Whether dealing damage should be disabled or not (will crash with cs2fixes since they hook/detour damage regardless of you using their feature). Default value: true

--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -1414,8 +1414,16 @@ namespace SharpTimer
 
             if (playerTimers[player.Slot].TicksSinceLastCmd < cmdCooldown)
             {
-                player.PrintToChat(msgPrefix + $" Command is on cooldown. Chill...");
-                return;
+
+                if (playerTimers[player.Slot].TicksSinceLastCmd < cmdsaveLocCooldown)
+                {
+                    continue;
+                }
+                else{
+                    player.PrintToChat(msgPrefix + $" Saveloc is on cooldown. Chill...");
+                    return;
+                }
+                
             }
 
             if (playerTimers[player.Slot].IsReplaying)

--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -1415,9 +1415,9 @@ namespace SharpTimer
             if (playerTimers[player.Slot].TicksSinceLastCmd < cmdCooldown)
             {
 
-                if (playerTimers[player.Slot].TicksSinceLastCmd < cmdsaveLocCooldown)
+                if (playerTimers[player.Slot].TicksSinceLastCmd > cmdSavelocCooldown)
                 {
-                    continue;
+                    //Updated do nothing
                 }
                 else{
                     player.PrintToChat(msgPrefix + $" Saveloc is on cooldown. Chill...");

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -401,6 +401,28 @@ namespace SharpTimer
             }
         }
 
+        [ConsoleCommand("sharptimer_command_saveloc_cooldown", "Defines the time between savelocks can be called. Default value: 0.1")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerCmdSavelocCooldownConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            string args = command.ArgString;
+
+
+            
+            if (float.TryParse(args, out float saveLocCooldown) && saveLocCooldown >= 0)
+            {
+                cmdsaveLocCooldown = (int)(saveLocCooldown * 64);
+                SharpTimerConPrint($"SharpTimer saveloc command cooldown set to {saveLocCooldown} seconds.");
+            }
+            else
+            {
+                SharpTimerConPrint("Invalid command savelocCooldown value. Please provide a positive float.");
+            }
+        }
+
+
+        
+
         [ConsoleCommand("sharptimer_max_bhop_block_time", "Defines the time the player is allowed to stand on a Bhop block (if the map supports it). Default value: 1")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
         public void SharpTimerBhopBlockConvar(CCSPlayerController? player, CommandInfo command)

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -401,9 +401,9 @@ namespace SharpTimer
             }
         }
 
-        [ConsoleCommand("sharptimer_command_saveloc_cooldown", "Defines the time between savelocks can be called. Default value: 0.1")]
+        [ConsoleCommand("sharptimer_command_saveloc_cooldown", "Defines the time between savelocks can be called. Default value: 0.2")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
-        public void SharpTimerCmdSavelocCooldownConvar(CCSPlayerController? player, CommandInfo command)
+        public void SharpTimercmdSavelocCooldownConvar(CCSPlayerController? player, CommandInfo command)
         {
             string args = command.ArgString;
 
@@ -411,7 +411,7 @@ namespace SharpTimer
             
             if (float.TryParse(args, out float saveLocCooldown) && saveLocCooldown >= 0)
             {
-                cmdsaveLocCooldown = (int)(saveLocCooldown * 64);
+                cmdSavelocCooldown = (int)(saveLocCooldown * 64);
                 SharpTimerConPrint($"SharpTimer saveloc command cooldown set to {saveLocCooldown} seconds.");
             }
             else

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -26,7 +26,7 @@ namespace SharpTimer
         public string compileTimeStamp = new DateTime(CompileTimeStamp.CompileTime, DateTimeKind.Utc).ToString();
 
         public override string ModuleName => "SharpTimer";
-        public override string ModuleVersion => $"0.2.6 - {compileTimeStamp}";
+        public override string ModuleVersion => $"0.2.7 - {compileTimeStamp}";
         public override string ModuleAuthor => "dea https://github.com/deafps/";
         public override string ModuleDescription => "A CS2 Timer Plugin";
 

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -137,6 +137,7 @@ namespace SharpTimer
         public bool fovChangerEnabled = true;
         public bool triggerPushFixEnabled = false;
         public int cmdCooldown = 64;
+        public int cmdSavelocCooldown = 64;
         public float fakeTriggerHeight = 50;
         public int altVeloMaxSpeed = 3000;
         public bool forcePlayerSpeedEnabled = false;


### PR DESCRIPTION
A server I was playing in had set the command cooldown time higher than normal and css_tp commands would also get affected.
I separated the teleport cooldown in the configs with a new variable "sharptimer_command_saveloc_cooldown" accepting floats like the "sharptimer_command_spam_cooldown" variable.

I also made necessary changes to ChatCommands.cs for the css_tp command:

                if (playerTimers[player.Slot].TicksSinceLastCmd > cmdSavelocCooldown)
                {
                    //Updated do nothing
                }

Tested today and it seems to work.